### PR TITLE
no :release/labels attribute, but :release/label

### DIFF
--- a/schema.edn
+++ b/schema.edn
@@ -273,9 +273,9 @@
   :db.install/_attribute :db.part/db}
 
  {:db/id #db/id[:db.part/db]
-  :db/ident :release/labels
+  :db/ident :release/label
   :db/valueType :db.type/ref
-  :db/cardinality :db.cardinality/many
+  :db/cardinality :db.cardinality/one
   :db/doc "The label on which the recording was released"
   :db.install/_attribute :db.part/db}
 


### PR DESCRIPTION
In the datomic-mbrainz-backup-20130611 there is no :release/labels attribute with db.cardinality/many. But there is a :release/label attribute with :db.cardinality/one.